### PR TITLE
fix: revert "chore: version 0.2.0"

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -42,7 +42,7 @@ jobs:
       - run: cargo install cargo-edit
 
       - name: Bump version
-        run: cargo set-version --bump "${{ inputs.releaseType }}"
+        run: cargo set-version --bump "${{ inputs.releaseType }}" && npm version ${{ inputs.releaseType }} --no-git-tag-version
 
       - name: Get version
         run: echo "IMMICH_VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages.[0].version')" >> $GITHUB_ENV

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "justified_layout"
-version = "0.2.0"
+version = "0.0.0"
 edition = "2021"
 license = "AGPL-3"
 


### PR DESCRIPTION
The `Cargo.toml` file was still using 0.1.0, so it was bumped to 0.2.0 instead of 0.1.0. The `package.json` was not updated in the workflow and stayed at 0.0.0.