### PR TITLE
chore: include `.d.ts` file in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "files": [
     "pkg/justified-layout-wasm.js",
     "pkg/justified-layout-wasm_bg.js",
-    "pkg/justified-layout-wasm_bg.wasm"
+    "pkg/justified-layout-wasm_bg.wasm",
+    "pkg/justified-layout-wasm.d.ts"
   ],
   "main": "js/index.ts",
   "sideEffects": [


### PR DESCRIPTION
### Description

The index file is in TS, but the generated library is a JS file with separate `.d.ts` types. I *think* this should fix the failing check [here](https://github.com/immich-app/immich/actions/runs/12941132362/job/36096663188?pr=15524).