### PR TITLE
feat: bidirectional height tolerance

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
-[build]
+[target.wasm32-unknown-unknown]
 rustflags = ["-C", "target-feature=+simd128"]
 
 [unstable]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,11 @@ strip = true
 panic = "abort"
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["--enable-simd", "--fast-math", "--gufa", "-O3", "--type-finalizing"]
+wasm-opt = [
+  "--enable-simd",
+  "--fast-math",
+  "--enable-bulk-memory",
+  "--gufa",
+  "-O3",
+  "--type-finalizing",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,22 +11,24 @@ pub struct LayoutOptions {
 
 /// Given an input of aspect ratios representing boxes, returns a vector 4 times its length + 4.
 /// The first element is the maximum width across all rows, the second is the total height required
-/// to display all rows, the next two are padding, and the remaining elements are sequences of 4 
+/// to display all rows, the next two are padding, and the remaining elements are sequences of 4
 /// elements for each box, representing the top, left, width and height positions.
 /// `row_height` is a positive float that is the target height of the row.
 ///     It is not strictly followed; the actual height may be off by one due to truncation, and may be
 ///     substantially different if only one box can fit on a row and this box cannot fit with the
 ///     target height. The height cannot exceed this target unless `tolerance` is greater than zero.
 /// `row_width` is a positive float that is the target width of the row.
-///     It will not be exceeded, but a row may have a shorter width if the boxes cannot fill the row
+///     It can be exceeded by a rounding error or shorter if the boxes cannot fill the row
 ///     width given the `tolerance`.
 /// `spacing` is a non-negative float that controls the spacing between boxes, including between rows.
 ///     Notably, there is no offset applied in directions where there is no box.
 ///     The first box will have its top and left positions both at 0, not at `spacing`, and so on.
 /// `tolerance` is a non-negative float that gives more freedom to fill the row width.
 ///     When there is free space in the row and the next box cannot fit in this row, it can scale
-///     the boxes to a larger height to fill this space while respecting aspect ratios. A value of
-///     0.15 signifies that the actual row height may be up to 15% greater than the target height.
+///     the boxes to a larger height to fill this space while respecting aspect ratios. Additionally,
+///     the height can be shorter if shrinking the row height would allow more boxes to fit
+///     in the row without causing the height to be more off from the target height. A value of 0.15
+///     signifies that the actual row height may be up to 15% shorter or taller than the target height.
 ///
 /// Note: The response being Vec<i32> rather than a struct or list of structs is important, as the
 ///       JS-WASM interop is *massively* slower when moving structs to JS instead of an array and
@@ -50,25 +52,33 @@ pub fn get_justified_layout(
 }
 
 #[inline(always)]
-fn _get_justified_layout(aspect_ratios: &[f32], options: LayoutOptions) -> Vec<i32> {
+pub fn _get_justified_layout(aspect_ratios: &[f32], options: LayoutOptions) -> Vec<i32> {
     let mut positions = vec![0.0; aspect_ratios.len() * 4 + 4]; // 2 for container width and height, 2 for alignment
+    let min_row_height = options.row_height * (1.0 - options.tolerance);
     let max_row_height = options.row_height * (1.0 + options.tolerance);
-    let mut cur_row_width = 0.0;
+    let mut cur_aspect_ratio = 0.0;
+    let mut row_aspect_ratio = 0.0;
     let mut max_actual_row_width = 0.0;
     let mut row_start_idx: usize = 0;
     let mut top = 0.0;
+    let max_row_aspect_ratio = options.row_width / min_row_height;
+    let target_row_aspect_ratio = options.row_width / options.row_height;
+    let spacing_aspect_ratio = options.spacing / options.row_height;
 
-    for (i, aspect_ratio) in aspect_ratios.iter().enumerate() {
-        let box_width = aspect_ratio * options.row_height;
-        cur_row_width += box_width;
+    let mut row_diff = target_row_aspect_ratio;
+    for i in 0..aspect_ratios.len() {
+        let aspect_ratio = aspect_ratios[i];
+        cur_aspect_ratio += aspect_ratio;
+        let cur_diff = (cur_aspect_ratio - target_row_aspect_ratio).abs();
 
         // there are no more boxes that can fit in this row
-        if cur_row_width > options.row_width && i > 0 {
+        if (cur_aspect_ratio > max_row_aspect_ratio || cur_diff > row_diff) && i > 0 {
             let row = &mut positions[row_start_idx * 4 + 4..i * 4 + 4];
             let aspect_ratio_row = &aspect_ratios[row_start_idx..i];
 
             // treat the row's boxes as a single entity and scale them to fit the row width
-            let total_aspect_ratio: f32 = aspect_ratio_row.iter().sum();
+            let total_aspect_ratio =
+                row_aspect_ratio - (spacing_aspect_ratio * aspect_ratio_row.len() as f32);
             let spacing_pixels = options.spacing * f32::from(aspect_ratio_row.len() as u16 - 1);
             let scaled_row_height =
                 ((options.row_width - spacing_pixels) / total_aspect_ratio).min(max_row_height);
@@ -90,17 +100,22 @@ fn _get_justified_layout(aspect_ratios: &[f32], options: LayoutOptions) -> Vec<i
             top += scaled_row_height + options.spacing;
             max_actual_row_width = actual_row_width.max(max_actual_row_width);
             row_start_idx = i;
-            cur_row_width = box_width;
+            cur_aspect_ratio = aspect_ratio;
+            row_diff = (cur_aspect_ratio - target_row_aspect_ratio).abs();
+        } else {
+            row_diff = cur_diff;
         }
-        cur_row_width += options.spacing;
+        cur_aspect_ratio += spacing_aspect_ratio;
+        row_aspect_ratio = cur_aspect_ratio;
     }
 
     // this is the same as in the for loop and processes the last row
     // inlined because it ends up producing much better assembly
     let row = &mut positions[row_start_idx * 4 + 4..];
     let aspect_ratio_row = &aspect_ratios[row_start_idx..];
-    let total_aspect_ratio: f32 = aspect_ratio_row.iter().sum();
-    let spacing_pixels = options.spacing * f32::from(aspect_ratio_row.len() as u16 - 1);
+    let total_aspect_ratio =
+        row_aspect_ratio - (spacing_aspect_ratio * aspect_ratio_row.len() as f32);
+    let spacing_pixels = options.spacing * (aspect_ratio_row.len() as u16 - 1) as f32;
     let scaled_row_height =
         ((options.row_width - spacing_pixels) / total_aspect_ratio).min(max_row_height);
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -425,3 +425,118 @@ fn one_box_on_each_row_with_scaling() {
     assert_eq!(width3, 194);
     assert_eq!(height3, 345);
 }
+
+#[wasm_bindgen_test]
+fn add_box_to_full_row_when_it_helps() {
+    let input: Vec<f32> = vec![
+        1.5,
+        0.6666666666666666,
+        1.3274336283185841,
+        1.3333333333333333,
+        0.7516666666666667,
+        1.5,
+        0.665,
+        1.4018691588785046,
+        1.3392857142857142,
+    ];
+    let row_width = 350.0;
+    let row_height = 75.0;
+    let spacing = 4.0;
+    let height_tolerance = 0.15;
+
+    let layout = get_justified_layout(
+        input.as_slice(),
+        row_height,
+        row_width,
+        spacing,
+        height_tolerance,
+    );
+    // assert_eq!(layout, vec![]);
+    assert_eq!(layout.len(), 40);
+    let max_row_width = layout[0];
+    assert_eq!(max_row_width, 351);
+
+    let [top1, left1, width1, height1] = layout[4..8] else {
+        unreachable!()
+    };
+    assert_eq!(top1, 0);
+    assert_eq!(left1, 0);
+    assert_eq!(width1, 105);
+    assert_eq!(height1, 70);
+
+    let [top2, left2, width2, height2] = layout[8..12] else {
+        unreachable!()
+    };
+    assert_eq!(top2, 0);
+    assert_eq!(left2, width1 + spacing as i32);
+    assert_eq!(width2, 46);
+    assert_eq!(height2, 70);
+
+    let [top3, left3, width3, height3] = layout[12..16] else {
+        unreachable!()
+    };
+    assert_eq!(top3, 0);
+    assert_eq!(left3, width1 + spacing as i32 + width2 + spacing as i32);
+    assert_eq!(width3, 92);
+    assert_eq!(height3, 70);
+
+    let [top4, left4, width4, height4] = layout[16..20] else {
+        unreachable!()
+    };
+    assert_eq!(top4, 0);
+    assert_eq!(
+        left4,
+        width1 + spacing as i32 + width2 + spacing as i32 + width3 + spacing as i32 + 1
+    );
+    assert_eq!(width4, 93); // should be 92
+    assert_eq!(height4, 70);
+
+    let [top5, left5, width5, height5] = layout[20..24] else {
+        unreachable!()
+    };
+    assert_eq!(top5, height1 + spacing as i32);
+    assert_eq!(left5, 0);
+    assert_eq!(width5, 58);
+    assert_eq!(height5, 78);
+
+    let [top6, left6, width6, height6] = layout[24..28] else {
+        unreachable!()
+    };
+    assert_eq!(top6, height1 + spacing as i32);
+    assert_eq!(left6, width5 + spacing as i32);
+    assert_eq!(width6, 117);
+    assert_eq!(height6, 78);
+
+    let [top7, left7, width7, height7] = layout[28..32] else {
+        unreachable!()
+    };
+    assert_eq!(top7, height1 + spacing as i32);
+    assert_eq!(left7, width5 + spacing as i32 + width6 + spacing as i32 + 1);
+    assert_eq!(width7, 52);
+    assert_eq!(height7, 78);
+
+    let [top8, left8, width8, height8] = layout[32..36] else {
+        unreachable!()
+    };
+    assert_eq!(top8, height1 + spacing as i32);
+    assert_eq!(
+        left8,
+        width5 + spacing as i32 + width6 + spacing as i32 + width7 + spacing as i32 + 1
+    );
+    assert_eq!(width8, 109);
+    assert_eq!(height8, 78);
+
+    let [top9, left9, width9, height9] = layout[36..40] else {
+        unreachable!()
+    };
+    assert_eq!(top9, height1 + spacing as i32 + height5 + spacing as i32);
+    assert_eq!(left9, 0);
+    assert_eq!(width9, 115);
+    assert_eq!(height9, 86);
+
+    let max_row_height = layout[1];
+    assert_eq!(
+        max_row_height,
+        height1 + spacing as i32 + height5 + spacing as i32 + height9 + 1
+    );
+}


### PR DESCRIPTION
This PR improves layout calculation by allowing the row height to go below the target height in certain conditions. I added the layout in the test code provided in #9 as a test to confirm the improved behavior.

I first implemented the approach in #9, which made the inner row calculation significantly slower, making the overall algorithm up to 78% slower if every box is placed on its own row. The algorithm in this PR doesn't have this issue and performs similarly to main, often outperforming it.

The below chart shows the time in ms to calculate 10 million boxes on a MBA M1 given a certain row width (and height=235, tolerance=0.15, spacing=2). For each width, I ran 100 trials and averaged the result.

|    | 250    | 500    | 1000   | 2000   | 4000   | 8000   |
|----|:---:|:---:|:---:|:---:|:---:|:---:|
| main | 67.353 | 83.074 | 74.995 | 65.604 | 62.744 | 64.167 |
| PR | 55.750 | 82.521 | 73.627 | 69.477 | 62.775 | 59.956 |

For both variants, there is a degradation at 1000 and (especially) 500. I think this is because the branch prediction performs poorly here.

Fixes #9