### PR TITLE
fix: don't strip release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ wasm-bindgen-test = "0.3.0"
 [profile.release]
 lto = true
 codegen-units = 1
-strip = true
 panic = "abort"
 
 [package.metadata.wasm-pack.profile.release]


### PR DESCRIPTION
wasm-opt is failing in CI. It's probably failing to infer what features are available since the pre-optimization build is stripped.