### PR TITLE
chore: init function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A blazingly fast implementation of the justified layout gallery view popularized
 npm i @immich/justified-layout-wasm
 ```
 
-Note that you will need to have both WebAssembly ESM integration and possibly top-level await configured for your project. For Vite, this means using [vite-plugin-wasm](https://www.npmjs.com/package/vite-plugin-wasm) and possibly [vite-plugin-top-level-await](https://www.npmjs.com/package/vite-plugin-top-level-await).
+Note that you will need to have both WebAssembly ESM integration configured for your project. For Vite, this means using [vite-plugin-wasm](https://www.npmjs.com/package/vite-plugin-wasm).
 
 Additionally, you should exclude this package from dependency optimization as it may interfere with the initialization of the Wasm module. For Vite, this means using the `optimizeDeps.exclude` field in `vite.config.js`:
 ```js
@@ -30,7 +30,10 @@ npm run build
 ## Usage (TS)
 
 ```ts
-import { JustifiedLayout } from '@immich/justified-layout-wasm';
+import init, { JustifiedLayout } from '@immich/justified-layout-wasm';
+
+// this needs to be called before `JustifiedLayout` can be used with non-empty inputs
+await init();
 
 const boxes = [{ width: 160, height: 90 }, { width: 200, height: 100 }, { width: 90, height: 160 }];
 const aspectRatios = new Float32Array(boxes.map(({ width, height }) => width / height));

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "@immich/justified-layout-wasm",
-  "type": "module",
   "version": "0.2.1",
   "license": "AGPL-3",
   "scripts": {
-    "build": "wasm-pack build --no-pack --out-name justified-layout-wasm"
+    "build": "wasm-pack build --no-pack --out-name justified-layout-wasm --target web"
   },
   "files": [
     "pkg/justified-layout-wasm.js",


### PR DESCRIPTION
The package currently relies on top-level await for module initialization. Due to an ongoing WebKit bug, module imports containing top-level await don't get initialized properly. Moreover, bundlers like Vite make it difficult to control when the import actually happens, meaning it is not enough to "pre-import" the module in a different part of the web code.

This PR changes the build method to use the more established async `init` function instead. This makes its usage much easier: just throw this init function in a layout.ts file and use and import the module as normal in the actual call sites.