### PR TITLE
feat: make last row match height of previous row

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,11 +118,15 @@ pub fn _get_justified_layout(aspect_ratios: &[f32], options: LayoutOptions) -> V
 
     let base_row_height = (options.row_width - spacing_pixels) / total_aspect_ratio;
     // try to match the height of the previous row
-    let scaled_row_height = if row_start_idx > 0 {
-        // SAFETY: this is guaranteed to be within bounds
-        base_row_height.min(unsafe { *positions.get_unchecked(row_start_idx * 4 + 3) })
+    let scaled_row_height = if base_row_height > max_row_height {
+        if row_start_idx > 0 {
+            // SAFETY: this is guaranteed to be within bounds
+            unsafe { *positions.get_unchecked(row_start_idx * 4 + 3) }
+        } else {
+            max_row_height
+        }
     } else {
-        base_row_height.min(max_row_height)
+        base_row_height
     };
 
     let row = &mut positions[row_start_idx * 4 + 4..];

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -399,7 +399,7 @@ fn one_box_on_each_row_with_scaling() {
     assert_eq!(max_row_width, 600.0);
 
     let max_row_height = layout[1];
-    assert_eq!(max_row_height, 337.5 + 2.0 + 300.0 + 2.0 + 345.0);
+    assert_eq!(max_row_height, 337.5 + 2.0 + 300.0 + 2.0 + 300.0);
 
     let [top1, left1, width1, height1] = layout[4..8] else {
         unreachable!()
@@ -422,8 +422,8 @@ fn one_box_on_each_row_with_scaling() {
     };
     assert_eq!(top3, height1 + spacing + height2 + spacing);
     assert_eq!(left3, 0.0);
-    assert_eq!(width3, 194.0625);
-    assert_eq!(height3, 345.0);
+    assert_eq!(width3, 168.75);
+    assert_eq!(height3, 300.0);
 }
 
 #[wasm_bindgen_test]
@@ -451,7 +451,6 @@ fn add_box_to_full_row_when_it_helps() {
         spacing,
         height_tolerance,
     );
-    // assert_eq!(layout, vec![]);
     assert_eq!(layout.len(), 40);
     let max_row_width = layout[0];
     assert_eq!(max_row_width, 350.00003);
@@ -531,8 +530,8 @@ fn add_box_to_full_row_when_it_helps() {
     };
     assert_eq!(top9, height1 + spacing + height5 + spacing);
     assert_eq!(left9, 0.0);
-    assert_eq!(width9, 115.5134);
-    assert_eq!(height9, 86.25);
+    assert_eq!(width9, 104.822235);
+    assert_eq!(height9, 78.267265);
 
     let max_row_height = layout[1];
     assert_eq!(

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -539,3 +539,45 @@ fn add_box_to_full_row_when_it_helps() {
         height1 + spacing + height5 + spacing + height9
     );
 }
+
+#[wasm_bindgen_test]
+fn fills_last_row_when_within_max_row_height() {
+    let input: Vec<f32> = vec![
+        1.5,
+        0.6666666666666666,
+        1.3274336283185841,
+        1.3333333333333333,
+        0.7516666666666667,
+        1.5,
+        0.665,
+        1.4018691588785046,
+        1.3392857142857142,
+        0.5625,
+    ];
+    let row_width = 640.0;
+    let row_height = 100.0;
+    let spacing = 2.0;
+    let height_tolerance = 0.2;
+
+    let layout = get_justified_layout(
+        input.as_slice(),
+        row_height,
+        row_width,
+        spacing,
+        height_tolerance,
+    );
+    assert_eq!(layout.len(), 44);
+    let max_row_width = layout[0];
+    assert_eq!(max_row_width, 640.00006);
+
+    let max_row_height = layout[1];
+    assert_eq!(max_row_height, 230.84763);
+
+    let [top10, left10, width10, height10] = layout[40..44] else {
+        unreachable!()
+    };
+    assert_eq!(top10, 115.279915);
+    assert_eq!(left10, 574.99316);
+    assert_eq!(width10, 65.00684);
+    assert_eq!(height10, 115.56772);
+}


### PR DESCRIPTION
This change makes the last row more visually consistent, matching the Flickr algorithm in this respect.

Before:

<img width="1082" height="707" alt="Screenshot 2025-07-31 at 6 46 54 PM" src="https://github.com/user-attachments/assets/10937418-3c2d-48f8-a1ca-41b303aabfaa" />

After:

<img width="1080" height="582" alt="Screenshot 2025-07-31 at 6 47 12 PM" src="https://github.com/user-attachments/assets/56466a50-3e0e-46c3-b238-9d2e3b969657" />

Closes #20